### PR TITLE
Fix PHP 8.2+ deprecation warning

### DIFF
--- a/src/Settings.php
+++ b/src/Settings.php
@@ -86,9 +86,9 @@ class Settings {
 	public function add_pages() {
 		$pages = [ 'menu_page', 'submenu_page' ];
 		foreach ( $pages as $page ) {
-			if ( $this->hasConfigKey( "${page}s" ) ) {
-				$pages = $this->getConfigKey( "${page}s" );
-				array_walk( $pages, [ $this, 'add_page' ], "add_${page}" );
+			if ( $this->hasConfigKey( "{$page}s" ) ) {
+				$pages = $this->getConfigKey( "{$page}s" );
+				array_walk( $pages, [ $this, 'add_page' ], "add_{$page}" );
 			}
 		}
 	}


### PR DESCRIPTION
When using this library in combination with PHP 8.2, a deprecation for the usage of the deprecated string interpolation is show:

```
PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/vendor/brightnucleus/settings/src/Settings.php on line 89
PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/vendor/brightnucleus/settings/src/Settings.php on line 90
PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/vendor/brightnucleus/settings/src/Settings.php on line 91
```

This commit fixes the issue by changing the dynamic string interpolation to a variant, that works with all PHP versions.

https://php.watch/versions/8.2/$%7Bvar%7D-string-interpolation-deprecated
https://3v4l.org/fCbaC
